### PR TITLE
Use java.net package (available on Android) instead of Apache HttpComponents 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 .classpath
 .settings
 log.txt
+.idea/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
-			<version>4.3</version>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.4</version>
 		</dependency>
 
 		<!-- Test Related Deps -->

--- a/src/main/java/com/cd/reddit/Reddit.java
+++ b/src/main/java/com/cd/reddit/Reddit.java
@@ -19,7 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.cd.reddit.http.apache.RedditApacheRequestor;
+import com.cd.reddit.http.RedditRequestor;
 import com.cd.reddit.http.util.RedditApiParameterConstants;
 import com.cd.reddit.http.util.RedditApiResourceConstants;
 import com.cd.reddit.http.util.RedditRequestInput;
@@ -31,10 +31,10 @@ import com.cd.reddit.json.mapping.RedditSubreddit;
 import com.cd.reddit.json.util.RedditComments;
 
 public class Reddit {
-	private final RedditApacheRequestor requestor;
+	private final RedditRequestor requestor;
 	
 	public Reddit(String userAgent){
-		requestor = new RedditApacheRequestor(userAgent);
+		requestor = new RedditRequestor(userAgent);
 	}
 	
 	public RedditJsonMessage login(final String userName, final String password) throws RedditException{

--- a/src/main/java/com/cd/reddit/http/QueryBuilder.java
+++ b/src/main/java/com/cd/reddit/http/QueryBuilder.java
@@ -1,0 +1,35 @@
+package com.cd.reddit.http;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: Austin
+ * Date: 10/3/13
+ * Time: 7:11 AM
+ * To change this template use File | Settings | File Templates.
+ */
+public class QueryBuilder {
+
+    private StringBuilder stringBuilder = new StringBuilder();
+
+    private static final String ENCODING = "UTF-8";
+
+    public void addParameter(String key, String value){
+        if(stringBuilder.length() > 0)
+            stringBuilder.append('&');
+        try {
+            stringBuilder.append(URLEncoder.encode(key, ENCODING))
+                .append('=')
+                .append(URLEncoder.encode(value, ENCODING));
+        } catch (UnsupportedEncodingException e) {
+            //This is a problem with the JVM, not ours.
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String build(){
+        return stringBuilder.toString();
+    }
+}

--- a/src/main/java/com/cd/reddit/http/RedditRequestor.java
+++ b/src/main/java/com/cd/reddit/http/RedditRequestor.java
@@ -28,7 +28,7 @@ import org.apache.commons.io.IOUtils;
 
 public class RedditRequestor {
 	
-	private static final String HOST = "www.reddit.com/";
+	private static final String HOST = "www.reddit.com";
 	
 	private final String userAgent;
 	
@@ -113,7 +113,7 @@ public class RedditRequestor {
         String query = "";
 		
 		if(pathSegments != null){
-			StringBuilder pathBuilder = new StringBuilder();
+			StringBuilder pathBuilder = new StringBuilder("/");
 			Iterator<String> itr = pathSegments.iterator();
 			
 			while(itr.hasNext()){
@@ -133,7 +133,7 @@ public class RedditRequestor {
 				builder.addParameter(entry.getKey(), entry.getValue());
 			}
 
-            query = builder.build();
+            query = "?" + builder.build();
 		}
 		
 		return new URL("http", HOST, path+query);


### PR DESCRIPTION
The `java.net` package is available on Android and is recommended over the outdated `org.apache.http` package. The final implementation is actually much simpler.

All tests pass successfully, and the Android test project runs flawlessly.
